### PR TITLE
Use the setAttribute and getAttribute methods for better extensibility

### DIFF
--- a/behaviors/MoneyFields.php
+++ b/behaviors/MoneyFields.php
@@ -53,13 +53,13 @@ class MoneyFields extends ModelBehavior
         $model = $this->model;
 
         $model->addDynamicMethod($methodName, function ($value) use ($model, $amountColumn, $currencyIdColumn) {
-            $model->attributes[$amountColumn] = empty($value['amount'])
+            $model->setAttribute($amountColumn, empty($value['amount'])
                     ? 0
-                    : Helpers::removeNonNumeric($value['amount']);
+                    : Helpers::removeNonNumeric($value['amount']));
 
-            $model->attributes[$currencyIdColumn] = empty($value['currency'])
+            $model->setAttribute($currencyIdColumn, empty($value['currency'])
                     ? Currency::getPrimary()->id
-                    : Currency::findByCode($value['currency'])->id;
+                    : Currency::findByCode($value['currency'])->id);
         });
     }
 
@@ -79,14 +79,15 @@ class MoneyFields extends ModelBehavior
         $model->addDynamicMethod($methodName, function ($value) use ($model, $amountColumn, $currencyIdColumn) {
             $value = [];
 
-            if (isset($model->$amountColumn)) {
-                $value['amount'] = (int) $model->$amountColumn;
+            if (isset($model->attributes[$amountColumn]) && ! empty($model->attributes[$amountColumn])) {
+                $value['amount'] = (int) $model->getAttribute($amountColumn);
             } else {
                 $value['amount'] = 0;
             }
 
             if (isset($model->$currencyIdColumn)) {
-                $value['currency'] = Currency::find($model->$currencyIdColumn)->currency_code;
+                $currencyId = $model->getAttribute($currencyIdColumn);
+                $value['currency'] = Currency::find($currencyId)->currency_code;
             } else {
                 $value['currency'] = Currency::getPrimary()->currency_code;
             }


### PR DESCRIPTION
Fixes #3.

Now, regarding [this change](https://github.com/msimkunas/oc-money-plugin/blob/b20f465dcc2c002c5d5c79ddbd1c8ba68d8891c8/behaviors/MoneyFields.php#L82) in particular.

`isset($model->$amountColumn)` calls the `__isset()` magic method which in turn calls the `getAttribute()` method of the base model class. This method triggers the `model.beforeGetAttribute` event.

The `Encryptable` trait in October listens to this event and [attempts to unencrypt the value if it is not null](https://github.com/octobercms/library/blob/a55d7118771eef8f2f8453acc353b42243aac27d/src/Database/Traits/Encryptable.php#L44) which results in an error when the amount value is set to 0.

Since 0 is a legitimate amount of money and should not be nulled (which would solve the problem by introducing a breaking change at the same time), we should avoid this issue entirely by checking the existence of the attribute directly in the model attributes array (i.e. `isset($model->attributes[$amountColumn])`).

Additionally, we also check if the value is not empty in order to not trigger the `model.beforeGetAttribute` event by calling the `getAttribute()` method ourselves. If you have any suggestions about a better and more robust way to check for attribute existence here, please share them.