### PR TITLE
Return null if the POSTed value is null

### DIFF
--- a/formwidgets/Money.php
+++ b/formwidgets/Money.php
@@ -96,6 +96,10 @@ class Money extends FormWidgetBase
             return FormField::NO_SAVE_DATA;
         }
 
+        if(empty($value)) {
+            return null;
+        }
+
         $value['amount'] = (int) Helpers::removeNonNumeric($value['amount']);
         return $value;
     }

--- a/formwidgets/Money.php
+++ b/formwidgets/Money.php
@@ -96,7 +96,7 @@ class Money extends FormWidgetBase
             return FormField::NO_SAVE_DATA;
         }
 
-        if(empty($value)) {
+        if(is_null($value)) {
             return null;
         }
 


### PR DESCRIPTION
Using the `getSaveData` method of the parent form widget throws the following error:

```
"Type error: Argument 1 passed to Initbiz\Money\Classes\Helpers::removeNonNumeric() must be of the type string, null given, called in /path/to/app/plugins/initbiz/money/formwidgets/Money.php on line 103" on line 15 of /path/to/app/plugins/initbiz/money/classes/Helpers.php
```

I figure this is because October [loops through](https://github.com/octobercms/october/blob/24f87ae10ebd97fe5f6ba4c2a87cf60d521f9861/modules/backend/widgets/Form.php#L1220-L1230) all of the form widgets attached to the parent form and attempts to retrieve their values from the POST array. If the value is not present, a `null` value is passed to the `getSaveValue` method at L1228 and the above error occurs.

This PR simply checks whether the passed value is not empty and returns `null` if that's the case.
