### PR TITLE
Fix down method in fraction_digits column migration

### DIFF
--- a/updates/update_responsive_currency_currencies_table.php
+++ b/updates/update_responsive_currency_currencies_table.php
@@ -14,8 +14,10 @@ class UpdateResponsiveCurrencyCurrenciesTable extends Migration
 
     public function down()
     {
-        Schema::table('responsiv_currency_currencies', function ($table) {
-            $table->dropColumn('initbiz_money_fraction_digits');
-        });
+        if (Schema::hasColumn('responsiv_currency_currencies', 'initbiz_money_fraction_digits')) {
+            Schema::table('responsiv_currency_currencies', function ($table) {
+                $table->dropColumn('initbiz_money_fraction_digits');
+            });
+        }
     }
 }


### PR DESCRIPTION
Error occured after php artisan october:down command

SQLSTATE[42S02]: Base table or view not found: 1146 Table 'octobercms.responsiv_currency_currencies' doesn't exist